### PR TITLE
Bugfix/artdaq logfiles error output

### DIFF
--- a/rc/control/daqinterface.py
+++ b/rc/control/daqinterface.py
@@ -1243,9 +1243,7 @@ class DAQInterface(Component):
                     if num_logfile_checks == max_num_logfile_checks:
                         self.print_log("e", "\nProblem associating logfiles with the artdaq processes. Output is as follows:")
                         self.print_log("e", "\nSTDOUT:\n======================================================================\n%s\n======================================================================\n" % ("".join(proclines)))
-                        self.print_log("e",
-                                "STDERR:\n======================================================================\n%s\n======================================================================\n"
-                                % ("".join([line.decode('utf-8') for line in proclines_err])))
+                        self.print_log("e", "STDERR:\n======================================================================\n%s\n======================================================================\n" % ("".join([line.decode('utf-8') for line in proclines_err])))
                         raise Exception(make_paragraph("Error: there was a problem identifying the logfiles for at least some of the artdaq processes. This may be the result of you not having write access to the directories where the logfiles are meant to be written. Please scroll up to see further output."))
                     else:
                         sleep(2)  # Give the logfiles a bit of time to appear before the next check

--- a/rc/control/daqinterface.py
+++ b/rc/control/daqinterface.py
@@ -1243,7 +1243,9 @@ class DAQInterface(Component):
                     if num_logfile_checks == max_num_logfile_checks:
                         self.print_log("e", "\nProblem associating logfiles with the artdaq processes. Output is as follows:")
                         self.print_log("e", "\nSTDOUT:\n======================================================================\n%s\n======================================================================\n" % ("".join(proclines)))
-                        self.print_log("e", "STDERR:\n======================================================================\n%s\n======================================================================\n" % ("".join(proclines_err)))
+                        self.print_log("e",
+                                "STDERR:\n======================================================================\n%s\n======================================================================\n"
+                                % ("".join([line.decode('utf-8') for line in proclines_err])))
                         raise Exception(make_paragraph("Error: there was a problem identifying the logfiles for at least some of the artdaq processes. This may be the result of you not having write access to the directories where the logfiles are meant to be written. Please scroll up to see further output."))
                     else:
                         sleep(2)  # Give the logfiles a bit of time to appear before the next check


### PR DESCRIPTION
Fix conversion from byte to string when output errors messages associated with artdaq logfiles.
This is the fix for the issue: https://github.com/art-daq/artdaq_daqinterface/issues/6 