### PR TITLE
Bugfix/149 package versions in metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required (VERSION 3.16)
 
 find_package(cetmodules)
 
-project(artdaq_daqinterface VERSION 3.12.07)
+project(artdaq_daqinterface VERSION 3.12.08)
 
 set(artdaq_daqinterface_NOARCH TRUE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required (VERSION 3.16)
 
 find_package(cetmodules)
 
-project(artdaq_daqinterface VERSION 3.12.08)
+project(artdaq_daqinterface VERSION 3.12.07)
 
 set(artdaq_daqinterface_NOARCH TRUE)
 

--- a/rc/control/daqinterface.py
+++ b/rc/control/daqinterface.py
@@ -2108,7 +2108,7 @@ class DAQInterface(Component):
 
             for line in stdoutlines:
                 if re.search(r"^(%s)\s+" % ("|".join(needed_packages)), line):
-                    (package, version) = line.split()
+                    (package, version) = line.split()[:2]
 
                     if not re.search(r"v[0-9]+_[0-9]+_[0-9]+.*", version):
                         raise Exception(


### PR DESCRIPTION
I took run 11586 @ Icarus from the ~/DAQ_ProdAreas/DAQ_2024-02-05_REL_v1_09_00 area and confirmed that metadata.txt contains sbndaq package versions.